### PR TITLE
Fix jellyfin_play tool not working

### DIFF
--- a/internal/server/tools/playback.go
+++ b/internal/server/tools/playback.go
@@ -220,16 +220,18 @@ func RegisterPlaybackTools(server *mcp.Server, client jf.Client, enabled func(st
 				playCmd = "PlayNow"
 			}
 
-			body := map[string]any{
-				"ItemIds":     args.ItemIDs,
-				"PlayCommand": playCmd,
+			params := url.Values{
+				"PlayCommand": {playCmd},
+			}
+			for _, itemID := range args.ItemIDs {
+				params.Add("ItemIds", itemID)
 			}
 			if args.StartIndex != nil {
-				body["StartIndex"] = *args.StartIndex
+				params.Set("StartIndex", fmt.Sprintf("%d", *args.StartIndex))
 			}
-
 			endpoint := fmt.Sprintf("/Sessions/%s/Playing", jf.SanitizeID(args.SessionID))
-			if err := client.PostNoContent(ctx, endpoint, nil, body); err != nil {
+
+			if err := client.PostNoContent(ctx, endpoint, params, nil); err != nil {
 				return jf.ErrResult("Failed to start playback: %v. Verify the session_id is valid using jellyfin_sessions.", err), nil, nil
 			}
 			return jf.TextResult(fmt.Sprintf("Playback started: %d items queued with command '%s'.", len(args.ItemIDs), playCmd)), nil, nil


### PR DESCRIPTION
The API takes parameters as params, not as a part of the body.  This fixes the following error:

```
{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"Failed to start playback: API error 400: {\"type\":\"https://tools.ietf.org/html/rfc9110#section-15.5.1\",\"title\":\"One or more validation errors occurred.\",\"status\":400,\"errors\":{\"playCommand\":[\"The playCommand field is required.\"]},\"traceId\":\"00-cb359698895a6307906c6cc22d49811e-16510ef108c3b7e1-00\"}. Verify the session_id is valid using jellyfin_sessions."}],"isError":true}}
```