### PR TITLE
Harden Jellyfin configuration and restricted MCP surfaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ JELLYFIN_URL=http://YOUR_SERVER:8096
 # Jellyfin User ID (optional, auto-detected if not set)
 # JELLYFIN_USER_ID=
 
+# Optionnel : exige JELLYFIN_USER_ID et interdit toute sélection automatique
+# d'un compte administrateur. --read-only n'active pas ce mode strict.
+# JELLYFIN_REQUIRE_USER_ID=false
+
 # Bearer token for HTTP transport / docker-compose (required when binding a
 # non-localhost address). Generate a long random secret.
 # HTTP_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,8 @@ JELLYFIN_URL=http://YOUR_SERVER:8096
 # Jellyfin User ID (optional, auto-detected if not set)
 # JELLYFIN_USER_ID=
 
-# Optionnel : exige JELLYFIN_USER_ID et interdit toute sélection automatique
-# d'un compte administrateur. --read-only n'active pas ce mode strict.
+# Optional: require JELLYFIN_USER_ID and disable automatic user selection,
+# including admin fallback. --read-only does not enable this strict mode.
 # JELLYFIN_REQUIRE_USER_ID=false
 
 # Bearer token for HTTP transport / docker-compose (required when binding a

--- a/README.md
+++ b/README.md
@@ -287,9 +287,10 @@ Image tags: `latest` (latest build from `main`), the full version from release t
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `JELLYFIN_API_KEY` | Yes | API key from your Jellyfin dashboard |
-| `JELLYFIN_URL` | No | Server URL — e.g. `http://YOUR_SERVER:8096`, or `https://YOUR_SERVER:8920` if HTTPS is enabled. Defaults to a placeholder, so set this. |
-| `JELLYFIN_USER_ID` | No | User ID — auto-detected from the API key if not set |
+| `JELLYFIN_API_KEY` | Yes | Clé API créée depuis le tableau de bord Jellyfin |
+| `JELLYFIN_URL` | Yes | URL HTTP(S) du serveur, par exemple `http://YOUR_SERVER:8096` ou `https://YOUR_SERVER:8920`. L'hôte d'exemple `jellyfin_host` est refusé au démarrage. |
+| `JELLYFIN_USER_ID` | No | ID utilisateur — détecté automatiquement depuis la clé API s'il est absent |
+| `JELLYFIN_REQUIRE_USER_ID` | No | Avec `true` ou `1`, exige `JELLYFIN_USER_ID` et interdit toute sélection automatique d'un compte administrateur |
 
 ### Toolsets
 
@@ -341,6 +342,8 @@ Beyond tools, jellyfin-mcp implements several MCP protocol features that compati
 ## Important notes
 
 **API key permissions** — The API key grants full access to whatever Jellyfin permissions are available. For shared or less trusted setups, pair it with `--read-only` or `--toolsets` to limit what the AI can do.
+
+`--read-only` limite la surface des outils, mais n'active pas le mode strict de sélection utilisateur. Pour interdire tout fallback vers un compte administrateur, configurez explicitement `JELLYFIN_USER_ID` et `JELLYFIN_REQUIRE_USER_ID=true`.
 
 **Network exposure** — In stdio mode, the server is only accessible to the local MCP client process. In HTTP mode, use `--http-token` whenever the server is reachable beyond localhost. The server refuses to start on a non-localhost address without a token.
 

--- a/README.md
+++ b/README.md
@@ -287,10 +287,10 @@ Image tags: `latest` (latest build from `main`), the full version from release t
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `JELLYFIN_API_KEY` | Yes | Clé API créée depuis le tableau de bord Jellyfin |
-| `JELLYFIN_URL` | Yes | URL HTTP(S) du serveur, par exemple `http://YOUR_SERVER:8096` ou `https://YOUR_SERVER:8920`. L'hôte d'exemple `jellyfin_host` est refusé au démarrage. |
-| `JELLYFIN_USER_ID` | No | ID utilisateur — détecté automatiquement depuis la clé API s'il est absent |
-| `JELLYFIN_REQUIRE_USER_ID` | No | Avec `true` ou `1`, exige `JELLYFIN_USER_ID` et interdit toute sélection automatique d'un compte administrateur |
+| `JELLYFIN_API_KEY` | Yes | API key from your Jellyfin dashboard |
+| `JELLYFIN_URL` | Yes | Jellyfin server HTTP(S) URL, for example `http://YOUR_SERVER:8096` or `https://YOUR_SERVER:8920`. The `jellyfin_host` placeholder is rejected at startup. |
+| `JELLYFIN_USER_ID` | No | User ID, auto-detected from the API key when omitted |
+| `JELLYFIN_REQUIRE_USER_ID` | No | When `true` or `1`, require `JELLYFIN_USER_ID` and disable automatic user selection, including admin fallback |
 
 ### Toolsets
 
@@ -343,9 +343,9 @@ Beyond tools, jellyfin-mcp implements several MCP protocol features that compati
 
 **API key permissions** — The API key grants full access to whatever Jellyfin permissions are available. For shared or less trusted setups, pair it with `--read-only` or `--toolsets` to limit what the AI can do.
 
-`--read-only` limite la surface des outils, mais n'active pas le mode strict de sélection utilisateur. Pour interdire tout fallback vers un compte administrateur, configurez explicitement `JELLYFIN_USER_ID` et `JELLYFIN_REQUIRE_USER_ID=true`.
+`--read-only` limits the tool surface, but it does not enable strict user selection. To prevent admin fallback, set an explicit `JELLYFIN_USER_ID` and `JELLYFIN_REQUIRE_USER_ID=true`.
 
-Avec `--read-only`, ou lorsque `--toolsets` n'inclut pas `admin`, les ressources `jellyfin://users` et `jellyfin://users/{userId}` ne sont pas exposées et la complétion des ID utilisateur n'interroge pas `/Users`.
+With `--read-only`, or when `--toolsets` does not include `admin`, the `jellyfin://users` and `jellyfin://users/{userId}` resources are not exposed, and user ID completion does not call `/Users`.
 
 **Network exposure** — In stdio mode, the server is only accessible to the local MCP client process. In HTTP mode, use `--http-token` whenever the server is reachable beyond localhost. The server refuses to start on a non-localhost address without a token.
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,8 @@ Beyond tools, jellyfin-mcp implements several MCP protocol features that compati
 
 `--read-only` limite la surface des outils, mais n'active pas le mode strict de sélection utilisateur. Pour interdire tout fallback vers un compte administrateur, configurez explicitement `JELLYFIN_USER_ID` et `JELLYFIN_REQUIRE_USER_ID=true`.
 
+Avec `--read-only`, ou lorsque `--toolsets` n'inclut pas `admin`, les ressources `jellyfin://users` et `jellyfin://users/{userId}` ne sont pas exposées et la complétion des ID utilisateur n'interroge pas `/Users`.
+
 **Network exposure** — In stdio mode, the server is only accessible to the local MCP client process. In HTTP mode, use `--http-token` whenever the server is reachable beyond localhost. The server refuses to start on a non-localhost address without a token.
 
 **Jellyfin version** — Tested against Jellyfin 10.8 through 10.11. Older versions may be missing some API endpoints (e.g., playback reporting, activity log queries).

--- a/internal/jellyfin/client.go
+++ b/internal/jellyfin/client.go
@@ -9,40 +9,48 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"os"
+	"strings"
 	"sync"
 	"time"
 )
 
 type JellyfinClient struct {
-	baseURL    string
-	apiKey     string
-	httpClient *http.Client
-	userID     string
-	mu         sync.Mutex
+	baseURL       string
+	apiKey        string
+	httpClient    *http.Client
+	userID        string
+	requireUserID bool
+	mu            sync.Mutex
 }
 
 func (c *JellyfinClient) BaseURL() string { return c.baseURL }
 func (c *JellyfinClient) APIKey() string  { return c.apiKey }
 
-// NewJellyfinClient creates a client from environment variables.
-// Exits if JELLYFIN_API_KEY is not set.
+// NewJellyfinClient crée un client depuis les variables d'environnement.
 func NewJellyfinClient() *JellyfinClient {
-	baseURL := os.Getenv("JELLYFIN_URL")
-	if baseURL == "" {
-		baseURL = "https://jellyfin_host:8920"
+	cfg, err := LoadClientConfigFromEnv()
+	if err != nil {
+		log.Fatalf("%v", err)
 	}
-	apiKey := os.Getenv("JELLYFIN_API_KEY")
-	if apiKey == "" {
-		log.Fatalf("JELLYFIN_API_KEY environment variable must be set")
+	client, err := NewClient(cfg)
+	if err != nil {
+		log.Fatalf("%v", err)
 	}
-	userID := os.Getenv("JELLYFIN_USER_ID")
+	return client
+}
+
+// NewClient construit un client depuis une configuration explicite.
+func NewClient(cfg ClientConfig) (*JellyfinClient, error) {
+	if err := ValidateClientConfig(cfg); err != nil {
+		return nil, err
+	}
 	return &JellyfinClient{
-		baseURL:    baseURL,
-		apiKey:     apiKey,
-		httpClient: &http.Client{Timeout: 30 * time.Second},
-		userID:     userID,
-	}
+		baseURL:       normalizeBaseURL(cfg.BaseURL),
+		apiKey:        cfg.APIKey,
+		httpClient:    &http.Client{Timeout: 30 * time.Second},
+		userID:        strings.TrimSpace(cfg.UserID),
+		requireUserID: cfg.RequireUserID,
+	}, nil
 }
 
 func (c *JellyfinClient) DoRequest(ctx context.Context, method, endpoint string, params url.Values, body any) ([]byte, error) {
@@ -217,6 +225,9 @@ func (c *JellyfinClient) GetUserID(ctx context.Context) (string, error) {
 	defer c.mu.Unlock()
 	if c.userID != "" {
 		return c.userID, nil
+	}
+	if c.requireUserID {
+		return "", fmt.Errorf("user ID not set: set JELLYFIN_USER_ID because JELLYFIN_REQUIRE_USER_ID is enabled")
 	}
 
 	// Try /Users/Me first -- works when the API token is a user auth token

--- a/internal/jellyfin/client.go
+++ b/internal/jellyfin/client.go
@@ -27,7 +27,7 @@ type JellyfinClient struct {
 func (c *JellyfinClient) BaseURL() string { return c.baseURL }
 func (c *JellyfinClient) APIKey() string  { return c.apiKey }
 
-// NewJellyfinClient crée un client depuis les variables d'environnement.
+// NewJellyfinClient creates a client from environment variables.
 func NewJellyfinClient() *JellyfinClient {
 	cfg, err := LoadClientConfigFromEnv()
 	if err != nil {
@@ -40,7 +40,7 @@ func NewJellyfinClient() *JellyfinClient {
 	return client
 }
 
-// NewClient construit un client depuis une configuration explicite.
+// NewClient constructs a client from explicit configuration.
 func NewClient(cfg ClientConfig) (*JellyfinClient, error) {
 	if err := ValidateClientConfig(cfg); err != nil {
 		return nil, err
@@ -218,7 +218,7 @@ func FetchAllPages(ctx context.Context, client Client, endpoint string, params u
 	return allItems, totalRecords, nil
 }
 
-// GetUserID renvoie l'identifiant mis en cache ou le résout une seule fois.
+// GetUserID returns the cached user ID or resolves it once.
 func (c *JellyfinClient) GetUserID(ctx context.Context) (string, error) {
 	for {
 		c.mu.Lock()

--- a/internal/jellyfin/client.go
+++ b/internal/jellyfin/client.go
@@ -21,6 +21,7 @@ type JellyfinClient struct {
 	userID        string
 	requireUserID bool
 	mu            sync.Mutex
+	userIDReady   chan struct{}
 }
 
 func (c *JellyfinClient) BaseURL() string { return c.baseURL }
@@ -159,7 +160,7 @@ func (c *JellyfinClient) PostRaw(ctx context.Context, endpoint string, params ur
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, MaxResponseBodyBytes))
 		return fmt.Errorf("API error %d: %s", resp.StatusCode, Truncate(string(respBody), ErrorBodyMaxLen))
 	}
 
@@ -217,26 +218,59 @@ func FetchAllPages(ctx context.Context, client Client, endpoint string, params u
 	return allItems, totalRecords, nil
 }
 
-// GetUserID returns the cached user ID, fetching on first call.
-// Resolution order: JELLYFIN_USER_ID env var -> /Users/Me (token-authenticated
-// user) -> first admin user from /Users.
+// GetUserID renvoie l'identifiant mis en cache ou le résout une seule fois.
 func (c *JellyfinClient) GetUserID(ctx context.Context) (string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.userID != "" {
-		return c.userID, nil
-	}
-	if c.requireUserID {
-		return "", fmt.Errorf("user ID not set: set JELLYFIN_USER_ID because JELLYFIN_REQUIRE_USER_ID is enabled")
-	}
+	for {
+		c.mu.Lock()
+		if c.userID != "" {
+			userID := c.userID
+			c.mu.Unlock()
+			return userID, nil
+		}
+		if c.requireUserID {
+			c.mu.Unlock()
+			return "", fmt.Errorf("user ID not set: set JELLYFIN_USER_ID because JELLYFIN_REQUIRE_USER_ID is enabled")
+		}
+		if c.userIDReady != nil {
+			ready := c.userIDReady
+			c.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return "", fmt.Errorf("waiting for user ID resolution: %w", ctx.Err())
+			case <-ready:
+				continue
+			}
+		}
 
+		ready := make(chan struct{})
+		c.userIDReady = ready
+		c.mu.Unlock()
+
+		userID, err := c.resolveUserID(ctx)
+
+		c.mu.Lock()
+		if err == nil && c.userID == "" {
+			c.userID = userID
+		}
+		if c.userID != "" {
+			userID = c.userID
+			err = nil
+		}
+		close(ready)
+		c.userIDReady = nil
+		c.mu.Unlock()
+
+		return userID, err
+	}
+}
+
+func (c *JellyfinClient) resolveUserID(ctx context.Context) (string, error) {
 	// Try /Users/Me first -- works when the API token is a user auth token
 	// and returns the correct user identity for the current session.
 	var me map[string]any
 	if err := c.Get(ctx, "/Users/Me", nil, &me); err == nil {
 		if id, ok := me["Id"].(string); ok && id != "" {
 			log.Printf("resolved user via /Users/Me: %s", id)
-			c.userID = id
 			return id, nil
 		}
 	}
@@ -263,7 +297,6 @@ func (c *JellyfinClient) GetUserID(ctx context.Context) (string, error) {
 		if policy, ok := u["Policy"].(map[string]any); ok {
 			if isAdmin, ok := policy["IsAdministrator"].(bool); ok && isAdmin {
 				log.Printf("auto-detected admin user ID: %s (set JELLYFIN_USER_ID to override)", id)
-				c.userID = id
 				return id, nil
 			}
 		}
@@ -273,6 +306,5 @@ func (c *JellyfinClient) GetUserID(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("no valid user ID found on Jellyfin server")
 	}
 	log.Printf("WARNING: no admin user found, using first user ID: %s (set JELLYFIN_USER_ID to override)", fallbackID)
-	c.userID = fallbackID
 	return fallbackID, nil
 }

--- a/internal/jellyfin/client_test.go
+++ b/internal/jellyfin/client_test.go
@@ -1,0 +1,86 @@
+package jellyfin
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestGetUserIDStrictModeNeverFallsBack(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int64
+	client := &JellyfinClient{
+		baseURL:       "http://jellyfin.local",
+		apiKey:        "secret",
+		requireUserID: true,
+		httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			requests.Add(1)
+			return jsonResponse(http.StatusOK, `[]`), nil
+		})},
+	}
+
+	_, err := client.GetUserID(context.Background())
+	if err == nil {
+		t.Fatal("mode strict sans identifiant accepté")
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("%d requête(s) réseau effectuée(s) en mode strict", requests.Load())
+	}
+}
+
+func TestGetUserIDPreservesAdminFallbackByDefault(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int64
+	client, err := NewClient(ClientConfig{
+		BaseURL: "http://jellyfin.local",
+		APIKey:  "secret",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		switch req.URL.Path {
+		case "/Users/Me":
+			return jsonResponse(http.StatusNotFound, `{"error":"not found"}`), nil
+		case "/Users":
+			return jsonResponse(http.StatusOK, `[
+				{"Id":"user-1","Policy":{"IsAdministrator":false}},
+				{"Id":"admin-1","Policy":{"IsAdministrator":true}}
+			]`), nil
+		default:
+			t.Fatalf("requête inattendue: %s", req.URL.Path)
+			return nil, nil
+		}
+	})}
+
+	userID, err := client.GetUserID(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if userID != "admin-1" {
+		t.Fatalf("GetUserID() = %q", userID)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("requêtes = %d, attendu 2", requests.Load())
+	}
+}

--- a/internal/jellyfin/client_test.go
+++ b/internal/jellyfin/client_test.go
@@ -41,10 +41,10 @@ func TestGetUserIDStrictModeNeverFallsBack(t *testing.T) {
 
 	_, err := client.GetUserID(context.Background())
 	if err == nil {
-		t.Fatal("mode strict sans identifiant accepté")
+		t.Fatal("strict mode accepted a missing user ID")
 	}
 	if requests.Load() != 0 {
-		t.Fatalf("%d requête(s) réseau effectuée(s) en mode strict", requests.Load())
+		t.Fatalf("%d network request(s) made in strict mode", requests.Load())
 	}
 }
 
@@ -70,7 +70,7 @@ func TestGetUserIDPreservesAdminFallbackByDefault(t *testing.T) {
 				{"Id":"admin-1","Policy":{"IsAdministrator":true}}
 			]`), nil
 		default:
-			t.Fatalf("requête inattendue: %s", req.URL.Path)
+			t.Fatalf("unexpected request: %s", req.URL.Path)
 			return nil, nil
 		}
 	})}
@@ -83,7 +83,7 @@ func TestGetUserIDPreservesAdminFallbackByDefault(t *testing.T) {
 		t.Fatalf("GetUserID() = %q", userID)
 	}
 	if requests.Load() != 2 {
-		t.Fatalf("requêtes = %d, attendu 2", requests.Load())
+		t.Fatalf("requests = %d, want 2", requests.Load())
 	}
 }
 
@@ -119,8 +119,8 @@ func TestPostRawBoundsErrorResponse(t *testing.T) {
 		name string
 		size int64
 	}{
-		{name: "à la limite", size: MaxResponseBodyBytes},
-		{name: "au-delà de la limite", size: MaxResponseBodyBytes + 1024},
+		{name: "at the limit", size: MaxResponseBodyBytes},
+		{name: "above the limit", size: MaxResponseBodyBytes + 1024},
 	}
 
 	for _, tt := range tests {
@@ -143,17 +143,17 @@ func TestPostRawBoundsErrorResponse(t *testing.T) {
 
 			err = client.PostRaw(context.Background(), "/Images/item", nil, []byte("image"), "image/jpeg")
 			if err == nil || !strings.Contains(err.Error(), "502") {
-				t.Fatalf("erreur inattendue: %v", err)
+				t.Fatalf("unexpected error: %v", err)
 			}
 			wantRead := tt.size
 			if wantRead > MaxResponseBodyBytes {
 				wantRead = MaxResponseBodyBytes
 			}
 			if body.read != wantRead {
-				t.Fatalf("octets lus = %d, attendu %d", body.read, wantRead)
+				t.Fatalf("bytes read = %d, want %d", body.read, wantRead)
 			}
 			if len(err.Error()) > ErrorBodyMaxLen+64 {
-				t.Fatalf("message d'erreur non borné: %d octets", len(err.Error()))
+				t.Fatalf("unbounded error message: %d bytes", len(err.Error()))
 			}
 		})
 	}
@@ -176,7 +176,7 @@ func TestGetUserIDDoesNotLockDuringRequest(t *testing.T) {
 	}
 	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.URL.Path != "/Users/Me" {
-			t.Fatalf("requête inattendue: %s", req.URL.Path)
+			t.Fatalf("unexpected request: %s", req.URL.Path)
 		}
 		requests.Add(1)
 		startOnce.Do(func() { close(requestStarted) })
@@ -198,7 +198,7 @@ func TestGetUserIDDoesNotLockDuringRequest(t *testing.T) {
 	select {
 	case <-requestStarted:
 	case <-time.After(time.Second):
-		t.Fatal("la requête de résolution n'a pas démarré")
+		t.Fatal("user ID resolution request did not start")
 	}
 
 	mutexAvailable := make(chan struct{})
@@ -210,7 +210,7 @@ func TestGetUserIDDoesNotLockDuringRequest(t *testing.T) {
 	select {
 	case <-mutexAvailable:
 	case <-time.After(time.Second):
-		t.Fatal("le mutex est conservé pendant la requête HTTP")
+		t.Fatal("mutex remained locked during the HTTP request")
 	}
 
 	close(releaseRequest)
@@ -223,6 +223,6 @@ func TestGetUserIDDoesNotLockDuringRequest(t *testing.T) {
 		}
 	}
 	if requests.Load() != 1 {
-		t.Fatalf("résolutions réseau = %d, attendu 1", requests.Load())
+		t.Fatalf("network resolutions = %d, want 1", requests.Load())
 	}
 }

--- a/internal/jellyfin/client_test.go
+++ b/internal/jellyfin/client_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -82,5 +84,145 @@ func TestGetUserIDPreservesAdminFallbackByDefault(t *testing.T) {
 	}
 	if requests.Load() != 2 {
 		t.Fatalf("requêtes = %d, attendu 2", requests.Load())
+	}
+}
+
+type generatedBody struct {
+	remaining int64
+	read      int64
+}
+
+func (body *generatedBody) Read(dst []byte) (int, error) {
+	if body.remaining == 0 {
+		return 0, io.EOF
+	}
+	size := int64(len(dst))
+	if size > body.remaining {
+		size = body.remaining
+	}
+	for i := int64(0); i < size; i++ {
+		dst[i] = 'x'
+	}
+	body.remaining -= size
+	body.read += size
+	return int(size), nil
+}
+
+func (*generatedBody) Close() error {
+	return nil
+}
+
+func TestPostRawBoundsErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		size int64
+	}{
+		{name: "à la limite", size: MaxResponseBodyBytes},
+		{name: "au-delà de la limite", size: MaxResponseBodyBytes + 1024},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := &generatedBody{remaining: tt.size}
+			client, err := NewClient(ClientConfig{
+				BaseURL: "http://jellyfin.local",
+				APIKey:  "secret",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			client.httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusBadGateway,
+					Header:     make(http.Header),
+					Body:       body,
+				}, nil
+			})}
+
+			err = client.PostRaw(context.Background(), "/Images/item", nil, []byte("image"), "image/jpeg")
+			if err == nil || !strings.Contains(err.Error(), "502") {
+				t.Fatalf("erreur inattendue: %v", err)
+			}
+			wantRead := tt.size
+			if wantRead > MaxResponseBodyBytes {
+				wantRead = MaxResponseBodyBytes
+			}
+			if body.read != wantRead {
+				t.Fatalf("octets lus = %d, attendu %d", body.read, wantRead)
+			}
+			if len(err.Error()) > ErrorBodyMaxLen+64 {
+				t.Fatalf("message d'erreur non borné: %d octets", len(err.Error()))
+			}
+		})
+	}
+}
+
+func TestGetUserIDDoesNotLockDuringRequest(t *testing.T) {
+	t.Parallel()
+
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var startOnce sync.Once
+	var requests atomic.Int64
+
+	client, err := NewClient(ClientConfig{
+		BaseURL: "http://jellyfin.local",
+		APIKey:  "secret",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/Users/Me" {
+			t.Fatalf("requête inattendue: %s", req.URL.Path)
+		}
+		requests.Add(1)
+		startOnce.Do(func() { close(requestStarted) })
+		<-releaseRequest
+		return jsonResponse(http.StatusOK, `{"Id":"user-1"}`), nil
+	})}
+
+	const callers = 8
+	results := make(chan string, callers)
+	errors := make(chan error, callers)
+	for range callers {
+		go func() {
+			userID, err := client.GetUserID(context.Background())
+			results <- userID
+			errors <- err
+		}()
+	}
+
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("la requête de résolution n'a pas démarré")
+	}
+
+	mutexAvailable := make(chan struct{})
+	go func() {
+		client.mu.Lock()
+		client.mu.Unlock()
+		close(mutexAvailable)
+	}()
+	select {
+	case <-mutexAvailable:
+	case <-time.After(time.Second):
+		t.Fatal("le mutex est conservé pendant la requête HTTP")
+	}
+
+	close(releaseRequest)
+	for range callers {
+		if err := <-errors; err != nil {
+			t.Fatal(err)
+		}
+		if userID := <-results; userID != "user-1" {
+			t.Fatalf("GetUserID() = %q", userID)
+		}
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("résolutions réseau = %d, attendu 1", requests.Load())
 	}
 }

--- a/internal/jellyfin/config.go
+++ b/internal/jellyfin/config.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// ClientConfig regroupe la configuration nécessaire au client Jellyfin.
+// ClientConfig contains the settings required by the Jellyfin client.
 type ClientConfig struct {
 	BaseURL       string
 	APIKey        string
@@ -16,7 +16,7 @@ type ClientConfig struct {
 	RequireUserID bool
 }
 
-// LoadClientConfigFromEnv lit la configuration du client depuis l'environnement.
+// LoadClientConfigFromEnv reads client configuration from the environment.
 func LoadClientConfigFromEnv() (ClientConfig, error) {
 	cfg := ClientConfig{
 		BaseURL: strings.TrimSpace(os.Getenv("JELLYFIN_URL")),
@@ -36,7 +36,7 @@ func LoadClientConfigFromEnv() (ClientConfig, error) {
 	return cfg, nil
 }
 
-// ValidateClientConfig vérifie la configuration avant toute requête réseau.
+// ValidateClientConfig validates configuration before any network request.
 func ValidateClientConfig(cfg ClientConfig) error {
 	if strings.TrimSpace(cfg.APIKey) == "" {
 		return fmt.Errorf("JELLYFIN_API_KEY environment variable must be set")
@@ -50,7 +50,7 @@ func ValidateClientConfig(cfg ClientConfig) error {
 	return nil
 }
 
-// ValidateJellyfinURL exige une URL HTTP(S) absolue et rejette l'hôte d'exemple.
+// ValidateJellyfinURL requires an absolute HTTP(S) URL and rejects the placeholder host.
 func ValidateJellyfinURL(raw string) error {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {

--- a/internal/jellyfin/config.go
+++ b/internal/jellyfin/config.go
@@ -1,0 +1,79 @@
+package jellyfin
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// ClientConfig regroupe la configuration nécessaire au client Jellyfin.
+type ClientConfig struct {
+	BaseURL       string
+	APIKey        string
+	UserID        string
+	RequireUserID bool
+}
+
+// LoadClientConfigFromEnv lit la configuration du client depuis l'environnement.
+func LoadClientConfigFromEnv() (ClientConfig, error) {
+	cfg := ClientConfig{
+		BaseURL: strings.TrimSpace(os.Getenv("JELLYFIN_URL")),
+		APIKey:  os.Getenv("JELLYFIN_API_KEY"),
+		UserID:  strings.TrimSpace(os.Getenv("JELLYFIN_USER_ID")),
+	}
+
+	rawRequireUserID := strings.TrimSpace(os.Getenv("JELLYFIN_REQUIRE_USER_ID"))
+	if rawRequireUserID != "" {
+		requireUserID, err := strconv.ParseBool(rawRequireUserID)
+		if err != nil {
+			return ClientConfig{}, fmt.Errorf("JELLYFIN_REQUIRE_USER_ID must be a boolean")
+		}
+		cfg.RequireUserID = requireUserID
+	}
+
+	return cfg, nil
+}
+
+// ValidateClientConfig vérifie la configuration avant toute requête réseau.
+func ValidateClientConfig(cfg ClientConfig) error {
+	if strings.TrimSpace(cfg.APIKey) == "" {
+		return fmt.Errorf("JELLYFIN_API_KEY environment variable must be set")
+	}
+	if err := ValidateJellyfinURL(cfg.BaseURL); err != nil {
+		return err
+	}
+	if cfg.RequireUserID && strings.TrimSpace(cfg.UserID) == "" {
+		return fmt.Errorf("JELLYFIN_USER_ID must be set when JELLYFIN_REQUIRE_USER_ID is enabled")
+	}
+	return nil
+}
+
+// ValidateJellyfinURL exige une URL HTTP(S) absolue et rejette l'hôte d'exemple.
+func ValidateJellyfinURL(raw string) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return fmt.Errorf("JELLYFIN_URL environment variable must be set")
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("JELLYFIN_URL must be a valid absolute URL")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("JELLYFIN_URL must use the http or https scheme")
+	}
+	if parsed.Host == "" || parsed.Hostname() == "" {
+		return fmt.Errorf("JELLYFIN_URL must include a host")
+	}
+	if strings.EqualFold(parsed.Hostname(), "jellyfin_host") {
+		return fmt.Errorf("JELLYFIN_URL must not use the jellyfin_host placeholder")
+	}
+
+	return nil
+}
+
+func normalizeBaseURL(raw string) string {
+	return strings.TrimRight(strings.TrimSpace(raw), "/")
+}

--- a/internal/jellyfin/config_test.go
+++ b/internal/jellyfin/config_test.go
@@ -1,0 +1,129 @@
+package jellyfin
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateJellyfinURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "absent", raw: "", wantErr: true},
+		{name: "espaces", raw: "   ", wantErr: true},
+		{name: "placeholder", raw: "https://jellyfin_host:8920", wantErr: true},
+		{name: "placeholder majuscules", raw: "http://JELLYFIN_HOST:8096", wantErr: true},
+		{name: "schéma absent", raw: "jellyfin.local:8096", wantErr: true},
+		{name: "schéma invalide", raw: "ftp://jellyfin.local", wantErr: true},
+		{name: "hôte absent", raw: "http:///jellyfin", wantErr: true},
+		{name: "port invalide", raw: "http://jellyfin.local:abc", wantErr: true},
+		{name: "http", raw: "http://jellyfin.local:8096"},
+		{name: "https", raw: "https://media.example.com"},
+		{name: "localhost", raw: "http://127.0.0.1:8096"},
+		{name: "ipv6", raw: "http://[::1]:8096"},
+		{name: "chemin reverse proxy", raw: "https://media.example.com/jellyfin/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateJellyfinURL(tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateJellyfinURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateClientConfig(t *testing.T) {
+	t.Parallel()
+
+	valid := ClientConfig{BaseURL: "http://localhost:8096", APIKey: "secret"}
+	if err := ValidateClientConfig(valid); err != nil {
+		t.Fatalf("configuration valide rejetée: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		cfg  ClientConfig
+	}{
+		{name: "clé API absente", cfg: ClientConfig{BaseURL: valid.BaseURL}},
+		{name: "URL absente", cfg: ClientConfig{APIKey: valid.APIKey}},
+		{
+			name: "identifiant strict absent",
+			cfg: ClientConfig{
+				BaseURL:       valid.BaseURL,
+				APIKey:        valid.APIKey,
+				RequireUserID: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := ValidateClientConfig(tt.cfg); err == nil {
+				t.Fatal("erreur attendue")
+			}
+		})
+	}
+
+	strict := valid
+	strict.RequireUserID = true
+	strict.UserID = "user-1"
+	if err := ValidateClientConfig(strict); err != nil {
+		t.Fatalf("configuration stricte valide rejetée: %v", err)
+	}
+}
+
+func TestLoadClientConfigFromEnv(t *testing.T) {
+	t.Setenv("JELLYFIN_URL", " https://media.example.com/jellyfin/ ")
+	t.Setenv("JELLYFIN_API_KEY", "secret")
+	t.Setenv("JELLYFIN_USER_ID", " user-1 ")
+	t.Setenv("JELLYFIN_REQUIRE_USER_ID", "true")
+
+	cfg, err := LoadClientConfigFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.BaseURL != "https://media.example.com/jellyfin/" {
+		t.Fatalf("BaseURL = %q", cfg.BaseURL)
+	}
+	if cfg.APIKey != "secret" || cfg.UserID != "user-1" || !cfg.RequireUserID {
+		t.Fatalf("configuration inattendue: %+v", cfg)
+	}
+
+	t.Setenv("JELLYFIN_REQUIRE_USER_ID", "not-a-boolean")
+	if _, err := LoadClientConfigFromEnv(); err == nil {
+		t.Fatal("valeur booléenne invalide acceptée")
+	}
+}
+
+func TestNewClientNormalizesURLWithoutLeakingAPIKey(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(ClientConfig{
+		BaseURL: " https://media.example.com/jellyfin/ ",
+		APIKey:  "secret",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := client.BaseURL(); got != "https://media.example.com/jellyfin" {
+		t.Fatalf("BaseURL = %q", got)
+	}
+
+	_, err = NewClient(ClientConfig{
+		BaseURL: ":// invalid",
+		APIKey:  "do-not-leak-this",
+	})
+	if err == nil {
+		t.Fatal("URL invalide acceptée")
+	}
+	if strings.Contains(err.Error(), "do-not-leak-this") {
+		t.Fatalf("la clé API apparaît dans l'erreur: %v", err)
+	}
+}

--- a/internal/jellyfin/config_test.go
+++ b/internal/jellyfin/config_test.go
@@ -13,19 +13,19 @@ func TestValidateJellyfinURL(t *testing.T) {
 		raw     string
 		wantErr bool
 	}{
-		{name: "absent", raw: "", wantErr: true},
-		{name: "espaces", raw: "   ", wantErr: true},
+		{name: "missing", raw: "", wantErr: true},
+		{name: "whitespace", raw: "   ", wantErr: true},
 		{name: "placeholder", raw: "https://jellyfin_host:8920", wantErr: true},
-		{name: "placeholder majuscules", raw: "http://JELLYFIN_HOST:8096", wantErr: true},
-		{name: "schéma absent", raw: "jellyfin.local:8096", wantErr: true},
-		{name: "schéma invalide", raw: "ftp://jellyfin.local", wantErr: true},
-		{name: "hôte absent", raw: "http:///jellyfin", wantErr: true},
-		{name: "port invalide", raw: "http://jellyfin.local:abc", wantErr: true},
+		{name: "uppercase placeholder", raw: "http://JELLYFIN_HOST:8096", wantErr: true},
+		{name: "missing scheme", raw: "jellyfin.local:8096", wantErr: true},
+		{name: "invalid scheme", raw: "ftp://jellyfin.local", wantErr: true},
+		{name: "missing host", raw: "http:///jellyfin", wantErr: true},
+		{name: "invalid port", raw: "http://jellyfin.local:abc", wantErr: true},
 		{name: "http", raw: "http://jellyfin.local:8096"},
 		{name: "https", raw: "https://media.example.com"},
 		{name: "localhost", raw: "http://127.0.0.1:8096"},
 		{name: "ipv6", raw: "http://[::1]:8096"},
-		{name: "chemin reverse proxy", raw: "https://media.example.com/jellyfin/"},
+		{name: "reverse proxy path", raw: "https://media.example.com/jellyfin/"},
 	}
 
 	for _, tt := range tests {
@@ -44,17 +44,17 @@ func TestValidateClientConfig(t *testing.T) {
 
 	valid := ClientConfig{BaseURL: "http://localhost:8096", APIKey: "secret"}
 	if err := ValidateClientConfig(valid); err != nil {
-		t.Fatalf("configuration valide rejetée: %v", err)
+		t.Fatalf("valid configuration rejected: %v", err)
 	}
 
 	tests := []struct {
 		name string
 		cfg  ClientConfig
 	}{
-		{name: "clé API absente", cfg: ClientConfig{BaseURL: valid.BaseURL}},
-		{name: "URL absente", cfg: ClientConfig{APIKey: valid.APIKey}},
+		{name: "missing API key", cfg: ClientConfig{BaseURL: valid.BaseURL}},
+		{name: "missing URL", cfg: ClientConfig{APIKey: valid.APIKey}},
 		{
-			name: "identifiant strict absent",
+			name: "strict user ID missing",
 			cfg: ClientConfig{
 				BaseURL:       valid.BaseURL,
 				APIKey:        valid.APIKey,
@@ -66,7 +66,7 @@ func TestValidateClientConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if err := ValidateClientConfig(tt.cfg); err == nil {
-				t.Fatal("erreur attendue")
+				t.Fatal("expected an error")
 			}
 		})
 	}
@@ -75,7 +75,7 @@ func TestValidateClientConfig(t *testing.T) {
 	strict.RequireUserID = true
 	strict.UserID = "user-1"
 	if err := ValidateClientConfig(strict); err != nil {
-		t.Fatalf("configuration stricte valide rejetée: %v", err)
+		t.Fatalf("valid strict configuration rejected: %v", err)
 	}
 }
 
@@ -93,12 +93,12 @@ func TestLoadClientConfigFromEnv(t *testing.T) {
 		t.Fatalf("BaseURL = %q", cfg.BaseURL)
 	}
 	if cfg.APIKey != "secret" || cfg.UserID != "user-1" || !cfg.RequireUserID {
-		t.Fatalf("configuration inattendue: %+v", cfg)
+		t.Fatalf("unexpected configuration: %+v", cfg)
 	}
 
 	t.Setenv("JELLYFIN_REQUIRE_USER_ID", "not-a-boolean")
 	if _, err := LoadClientConfigFromEnv(); err == nil {
-		t.Fatal("valeur booléenne invalide acceptée")
+		t.Fatal("invalid boolean value accepted")
 	}
 }
 
@@ -121,9 +121,9 @@ func TestNewClientNormalizesURLWithoutLeakingAPIKey(t *testing.T) {
 		APIKey:  "do-not-leak-this",
 	})
 	if err == nil {
-		t.Fatal("URL invalide acceptée")
+		t.Fatal("invalid URL accepted")
 	}
 	if strings.Contains(err.Error(), "do-not-leak-this") {
-		t.Fatalf("la clé API apparaît dans l'erreur: %v", err)
+		t.Fatalf("API key leaked in error: %v", err)
 	}
 }

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// validateHTTPAuth exige un jeton dès que l'écoute dépasse la boucle locale.
+func validateHTTPAuth(addr, token string) error {
+	if token == "" && httpTokenRequired(addr) {
+		return fmt.Errorf("--http-token is required when listening on non-localhost address %s", addr)
+	}
+	return nil
+}
+
+func httpTokenRequired(addr string) bool {
+	host, port, err := net.SplitHostPort(strings.TrimSpace(addr))
+	if err != nil || port == "" {
+		return true
+	}
+	if strings.EqualFold(host, "localhost") {
+		return false
+	}
+	ip := net.ParseIP(host)
+	return ip == nil || !ip.IsLoopback()
+}
+
+// bearerAuth protège le handler avec une comparaison de jeton en temps constant.
+func bearerAuth(next http.Handler, token string) http.Handler {
+	if token == "" {
+		return next
+	}
+	expected := []byte("Bearer " + token)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		actual := []byte(r.Header.Get("Authorization"))
+		if subtle.ConstantTimeCompare(actual, expected) != 1 {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// validateHTTPAuth exige un jeton dès que l'écoute dépasse la boucle locale.
+// validateHTTPAuth requires a token whenever the listener is not loopback-only.
 func validateHTTPAuth(addr, token string) error {
 	if token == "" && httpTokenRequired(addr) {
 		return fmt.Errorf("--http-token is required when listening on non-localhost address %s", addr)
@@ -28,7 +28,7 @@ func httpTokenRequired(addr string) bool {
 	return ip == nil || !ip.IsLoopback()
 }
 
-// bearerAuth protège le handler avec une comparaison de jeton en temps constant.
+// bearerAuth protects the handler with a constant-time token comparison.
 func bearerAuth(next http.Handler, token string) http.Handler {
 	if token == "" {
 		return next

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -22,13 +22,13 @@ func TestHTTPTokenRequired(t *testing.T) {
 		{addr: ":8080", want: true},
 		{addr: "192.168.1.20:8080", want: true},
 		{addr: "jellyfin.local:8080", want: true},
-		{addr: "adresse-invalide", want: true},
+		{addr: "invalid-address", want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.addr, func(t *testing.T) {
 			t.Parallel()
 			if got := httpTokenRequired(tt.addr); got != tt.want {
-				t.Fatalf("httpTokenRequired(%q) = %v, attendu %v", tt.addr, got, tt.want)
+				t.Fatalf("httpTokenRequired(%q) = %v, want %v", tt.addr, got, tt.want)
 			}
 		})
 	}
@@ -38,13 +38,13 @@ func TestValidateHTTPAuth(t *testing.T) {
 	t.Parallel()
 
 	if err := validateHTTPAuth("127.0.0.1:8080", ""); err != nil {
-		t.Fatalf("écoute locale rejetée: %v", err)
+		t.Fatalf("local listener rejected: %v", err)
 	}
 	if err := validateHTTPAuth("0.0.0.0:8080", "secret"); err != nil {
-		t.Fatalf("écoute authentifiée rejetée: %v", err)
+		t.Fatalf("authenticated listener rejected: %v", err)
 	}
 	if err := validateHTTPAuth("0.0.0.0:8080", ""); err == nil {
-		t.Fatal("écoute non locale sans jeton acceptée")
+		t.Fatal("non-local listener without a token accepted")
 	}
 }
 
@@ -58,22 +58,22 @@ func TestBearerAuth(t *testing.T) {
 		wantStatus    int
 		wantCalled    bool
 	}{
-		{name: "auth désactivée", wantStatus: http.StatusNoContent, wantCalled: true},
-		{name: "jeton absent", token: "secret", wantStatus: http.StatusUnauthorized},
+		{name: "authentication disabled", wantStatus: http.StatusNoContent, wantCalled: true},
+		{name: "missing token", token: "secret", wantStatus: http.StatusUnauthorized},
 		{
-			name:          "schéma invalide",
+			name:          "invalid scheme",
 			token:         "secret",
 			authorization: "Basic secret",
 			wantStatus:    http.StatusUnauthorized,
 		},
 		{
-			name:          "jeton invalide",
+			name:          "invalid token",
 			token:         "secret",
 			authorization: "Bearer wrong",
 			wantStatus:    http.StatusUnauthorized,
 		},
 		{
-			name:          "jeton valide",
+			name:          "valid token",
 			token:         "secret",
 			authorization: "Bearer secret",
 			wantStatus:    http.StatusNoContent,
@@ -98,10 +98,10 @@ func TestBearerAuth(t *testing.T) {
 			handler.ServeHTTP(response, request)
 
 			if response.Code != tt.wantStatus {
-				t.Fatalf("statut = %d, attendu %d", response.Code, tt.wantStatus)
+				t.Fatalf("status = %d, want %d", response.Code, tt.wantStatus)
 			}
 			if called != tt.wantCalled {
-				t.Fatalf("handler appelé = %v, attendu %v", called, tt.wantCalled)
+				t.Fatalf("handler called = %v, want %v", called, tt.wantCalled)
 			}
 		})
 	}

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -1,0 +1,108 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTPTokenRequired(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		addr string
+		want bool
+	}{
+		{addr: "127.0.0.1:8080"},
+		{addr: "127.0.0.2:8080"},
+		{addr: "localhost:8080"},
+		{addr: "[::1]:8080"},
+		{addr: "0.0.0.0:8080", want: true},
+		{addr: "[::]:8080", want: true},
+		{addr: ":8080", want: true},
+		{addr: "192.168.1.20:8080", want: true},
+		{addr: "jellyfin.local:8080", want: true},
+		{addr: "adresse-invalide", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			t.Parallel()
+			if got := httpTokenRequired(tt.addr); got != tt.want {
+				t.Fatalf("httpTokenRequired(%q) = %v, attendu %v", tt.addr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateHTTPAuth(t *testing.T) {
+	t.Parallel()
+
+	if err := validateHTTPAuth("127.0.0.1:8080", ""); err != nil {
+		t.Fatalf("écoute locale rejetée: %v", err)
+	}
+	if err := validateHTTPAuth("0.0.0.0:8080", "secret"); err != nil {
+		t.Fatalf("écoute authentifiée rejetée: %v", err)
+	}
+	if err := validateHTTPAuth("0.0.0.0:8080", ""); err == nil {
+		t.Fatal("écoute non locale sans jeton acceptée")
+	}
+}
+
+func TestBearerAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		token         string
+		authorization string
+		wantStatus    int
+		wantCalled    bool
+	}{
+		{name: "auth désactivée", wantStatus: http.StatusNoContent, wantCalled: true},
+		{name: "jeton absent", token: "secret", wantStatus: http.StatusUnauthorized},
+		{
+			name:          "schéma invalide",
+			token:         "secret",
+			authorization: "Basic secret",
+			wantStatus:    http.StatusUnauthorized,
+		},
+		{
+			name:          "jeton invalide",
+			token:         "secret",
+			authorization: "Bearer wrong",
+			wantStatus:    http.StatusUnauthorized,
+		},
+		{
+			name:          "jeton valide",
+			token:         "secret",
+			authorization: "Bearer secret",
+			wantStatus:    http.StatusNoContent,
+			wantCalled:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			called := false
+			handler := bearerAuth(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusNoContent)
+			}), tt.token)
+
+			request := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			if tt.authorization != "" {
+				request.Header.Set("Authorization", tt.authorization)
+			}
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+
+			if response.Code != tt.wantStatus {
+				t.Fatalf("statut = %d, attendu %d", response.Code, tt.wantStatus)
+			}
+			if called != tt.wantCalled {
+				t.Fatalf("handler appelé = %v, attendu %v", called, tt.wantCalled)
+			}
+		})
+	}
+}

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -75,10 +75,10 @@ func TestUserCompletionFollowsAdminSurface(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(hiddenResult.Completion.Values) != 0 {
-		t.Fatalf("complétions exposées sans surface admin: %v", hiddenResult.Completion.Values)
+		t.Fatalf("completions exposed without admin access: %v", hiddenResult.Completion.Values)
 	}
 	if client.usersCalls.Load() != 0 {
-		t.Fatal("/Users appelé alors que la surface admin est masquée")
+		t.Fatal("/Users called while admin access is hidden")
 	}
 
 	visibleResult, err := completionHandler(client, true)(context.Background(), request)
@@ -86,9 +86,9 @@ func TestUserCompletionFollowsAdminSurface(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(visibleResult.Completion.Values) != 1 || visibleResult.Completion.Values[0] != "user-1" {
-		t.Fatalf("complétions admin inattendues: %v", visibleResult.Completion.Values)
+		t.Fatalf("unexpected admin completions: %v", visibleResult.Completion.Values)
 	}
 	if client.usersCalls.Load() != 1 {
-		t.Fatalf("appels /Users = %d, attendu 1", client.usersCalls.Load())
+		t.Fatalf("/Users calls = %d, want 1", client.usersCalls.Load())
 	}
 }

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"context"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type completionClient struct {
+	usersCalls atomic.Int64
+}
+
+func (client *completionClient) Get(_ context.Context, endpoint string, _ url.Values, dest any) error {
+	if endpoint == "/Users" {
+		client.usersCalls.Add(1)
+		users := dest.(*[]map[string]any)
+		*users = []map[string]any{{"Id": "user-1", "Name": "Alice"}}
+	}
+	return nil
+}
+
+func (*completionClient) GetRaw(context.Context, string, url.Values) (string, error) {
+	return "", nil
+}
+
+func (*completionClient) Post(context.Context, string, url.Values, any, any) error {
+	return nil
+}
+
+func (*completionClient) PostNoContent(context.Context, string, url.Values, any) error {
+	return nil
+}
+
+func (*completionClient) PostRaw(context.Context, string, url.Values, []byte, string) error {
+	return nil
+}
+
+func (*completionClient) Del(context.Context, string, url.Values) error {
+	return nil
+}
+
+func (*completionClient) DoRequest(context.Context, string, string, url.Values, any) ([]byte, error) {
+	return nil, nil
+}
+
+func (*completionClient) GetUserID(context.Context) (string, error) {
+	return "user-1", nil
+}
+
+func (*completionClient) BaseURL() string {
+	return "http://jellyfin.local"
+}
+
+func (*completionClient) APIKey() string {
+	return "secret"
+}
+
+func TestUserCompletionFollowsAdminSurface(t *testing.T) {
+	t.Parallel()
+
+	request := &mcp.CompleteRequest{Params: &mcp.CompleteParams{
+		Ref: &mcp.CompleteReference{
+			Type: "ref/resource",
+			URI:  "jellyfin://users/{userId}",
+		},
+		Argument: mcp.CompleteParamsArgument{Name: "userId", Value: ""},
+	}}
+
+	client := &completionClient{}
+	hiddenResult, err := completionHandler(client, false)(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hiddenResult.Completion.Values) != 0 {
+		t.Fatalf("complétions exposées sans surface admin: %v", hiddenResult.Completion.Values)
+	}
+	if client.usersCalls.Load() != 0 {
+		t.Fatal("/Users appelé alors que la surface admin est masquée")
+	}
+
+	visibleResult, err := completionHandler(client, true)(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(visibleResult.Completion.Values) != 1 || visibleResult.Completion.Values[0] != "user-1" {
+		t.Fatalf("complétions admin inattendues: %v", visibleResult.Completion.Values)
+	}
+	if client.usersCalls.Load() != 1 {
+		t.Fatalf("appels /Users = %d, attendu 1", client.usersCalls.Load())
+	}
+}

--- a/internal/server/resources/access_test.go
+++ b/internal/server/resources/access_test.go
@@ -1,0 +1,128 @@
+package resources
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type stubClient struct{}
+
+func (*stubClient) Get(context.Context, string, url.Values, any) error {
+	return nil
+}
+
+func (*stubClient) GetRaw(context.Context, string, url.Values) (string, error) {
+	return "", nil
+}
+
+func (*stubClient) Post(context.Context, string, url.Values, any, any) error {
+	return nil
+}
+
+func (*stubClient) PostNoContent(context.Context, string, url.Values, any) error {
+	return nil
+}
+
+func (*stubClient) PostRaw(context.Context, string, url.Values, []byte, string) error {
+	return nil
+}
+
+func (*stubClient) Del(context.Context, string, url.Values) error {
+	return nil
+}
+
+func (*stubClient) DoRequest(context.Context, string, string, url.Values, any) ([]byte, error) {
+	return nil, nil
+}
+
+func (*stubClient) GetUserID(context.Context) (string, error) {
+	return "user-1", nil
+}
+
+func (*stubClient) BaseURL() string {
+	return "http://jellyfin.local"
+}
+
+func (*stubClient) APIKey() string {
+	return "secret"
+}
+
+func TestAdminResourcesEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		readOnly bool
+		toolsets string
+		want     bool
+	}{
+		{name: "surface complète", want: true},
+		{name: "lecture seule", readOnly: true},
+		{name: "sans admin", toolsets: "discovery,media"},
+		{name: "admin explicite", toolsets: "discovery, admin", want: true},
+		{name: "lecture seule prioritaire", readOnly: true, toolsets: "admin"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := AdminResourcesEnabled(tt.readOnly, tt.toolsets); got != tt.want {
+				t.Fatalf("AdminResourcesEnabled() = %v, attendu %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegisterResourcesScopesAdminResources(t *testing.T) {
+	t.Parallel()
+
+	for _, includeAdmin := range []bool{false, true} {
+		t.Run(map[bool]string{false: "masquées", true: "exposées"}[includeAdmin], func(t *testing.T) {
+			server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1"}, nil)
+			RegisterResources(server, &stubClient{}, includeAdmin)
+
+			clientTransport, serverTransport := mcp.NewInMemoryTransports()
+			if _, err := server.Connect(t.Context(), serverTransport, nil); err != nil {
+				t.Fatal(err)
+			}
+			client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1"}, nil)
+			session, err := client.Connect(t.Context(), clientTransport, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = session.Close() })
+
+			resources, err := session.ListResources(t.Context(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			templates, err := session.ListResourceTemplates(t.Context(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			hasUsersResource := false
+			for _, resource := range resources.Resources {
+				if resource.URI == "jellyfin://users" {
+					hasUsersResource = true
+				}
+			}
+			hasUsersTemplate := false
+			for _, template := range templates.ResourceTemplates {
+				if template.URITemplate == "jellyfin://users/{userId}" {
+					hasUsersTemplate = true
+				}
+			}
+			if hasUsersResource != includeAdmin || hasUsersTemplate != includeAdmin {
+				t.Fatalf(
+					"surface admin inattendue: resource=%v template=%v includeAdmin=%v",
+					hasUsersResource,
+					hasUsersTemplate,
+					includeAdmin,
+				)
+			}
+		})
+	}
+}

--- a/internal/server/resources/access_test.go
+++ b/internal/server/resources/access_test.go
@@ -59,17 +59,17 @@ func TestAdminResourcesEnabled(t *testing.T) {
 		toolsets string
 		want     bool
 	}{
-		{name: "surface complète", want: true},
-		{name: "lecture seule", readOnly: true},
-		{name: "sans admin", toolsets: "discovery,media"},
-		{name: "admin explicite", toolsets: "discovery, admin", want: true},
-		{name: "lecture seule prioritaire", readOnly: true, toolsets: "admin"},
+		{name: "full surface", want: true},
+		{name: "read only", readOnly: true},
+		{name: "without admin", toolsets: "discovery,media"},
+		{name: "explicit admin", toolsets: "discovery, admin", want: true},
+		{name: "read only takes precedence", readOnly: true, toolsets: "admin"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := AdminResourcesEnabled(tt.readOnly, tt.toolsets); got != tt.want {
-				t.Fatalf("AdminResourcesEnabled() = %v, attendu %v", got, tt.want)
+				t.Fatalf("AdminResourcesEnabled() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -79,7 +79,7 @@ func TestRegisterResourcesScopesAdminResources(t *testing.T) {
 	t.Parallel()
 
 	for _, includeAdmin := range []bool{false, true} {
-		t.Run(map[bool]string{false: "masquées", true: "exposées"}[includeAdmin], func(t *testing.T) {
+		t.Run(map[bool]string{false: "hidden", true: "exposed"}[includeAdmin], func(t *testing.T) {
 			server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1"}, nil)
 			RegisterResources(server, &stubClient{}, includeAdmin)
 
@@ -117,7 +117,7 @@ func TestRegisterResourcesScopesAdminResources(t *testing.T) {
 			}
 			if hasUsersResource != includeAdmin || hasUsersTemplate != includeAdmin {
 				t.Fatalf(
-					"surface admin inattendue: resource=%v template=%v includeAdmin=%v",
+					"unexpected admin surface: resource=%v template=%v includeAdmin=%v",
 					hasUsersResource,
 					hasUsersTemplate,
 					includeAdmin,

--- a/internal/server/resources/resources.go
+++ b/internal/server/resources/resources.go
@@ -11,7 +11,7 @@ import (
 	jf "github.com/jaredtrent/jellyfin-mcp/internal/jellyfin"
 )
 
-// AdminResourcesEnabled applique aux ressources la même surface que les outils admin.
+// AdminResourcesEnabled applies the admin tool surface to resources.
 func AdminResourcesEnabled(readOnly bool, toolsets string) bool {
 	if readOnly {
 		return false

--- a/internal/server/resources/resources.go
+++ b/internal/server/resources/resources.go
@@ -11,7 +11,23 @@ import (
 	jf "github.com/jaredtrent/jellyfin-mcp/internal/jellyfin"
 )
 
-func RegisterResources(server *mcp.Server, client jf.Client) {
+// AdminResourcesEnabled applique aux ressources la même surface que les outils admin.
+func AdminResourcesEnabled(readOnly bool, toolsets string) bool {
+	if readOnly {
+		return false
+	}
+	if toolsets == "" {
+		return true
+	}
+	for _, toolset := range strings.Split(toolsets, ",") {
+		if strings.TrimSpace(toolset) == "admin" {
+			return true
+		}
+	}
+	return false
+}
+
+func RegisterResources(server *mcp.Server, client jf.Client, includeAdmin bool) {
 
 	// --- jellyfin://server/info ---
 	server.AddResource(&mcp.Resource{
@@ -341,30 +357,32 @@ func RegisterResources(server *mcp.Server, client jf.Client) {
 	})
 
 	// --- jellyfin://users ---
-	server.AddResource(&mcp.Resource{
-		URI:         "jellyfin://users",
-		Name:        "User Accounts",
-		Title:       "Users",
-		Description: "All user accounts with admin status and last activity",
-		MIMEType:    "application/json",
-		Annotations: &mcp.Annotations{Audience: []mcp.Role{"assistant"}, Priority: 0.4},
-	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
-		var users []map[string]any
-		if err := client.Get(ctx, "/Users", nil, &users); err != nil {
-			return nil, fmt.Errorf("failed to get users: %w", err)
-		}
-		items := make([]map[string]any, 0, len(users))
-		for _, u := range users {
-			items = append(items, jf.ExtractUserSummary(u))
-		}
-		return &mcp.ReadResourceResult{
-			Contents: []*mcp.ResourceContents{{
-				URI:      "jellyfin://users",
-				MIMEType: "application/json",
-				Text:     jf.FormatJSON(items),
-			}},
-		}, nil
-	})
+	if includeAdmin {
+		server.AddResource(&mcp.Resource{
+			URI:         "jellyfin://users",
+			Name:        "User Accounts",
+			Title:       "Users",
+			Description: "All user accounts with admin status and last activity",
+			MIMEType:    "application/json",
+			Annotations: &mcp.Annotations{Audience: []mcp.Role{"assistant"}, Priority: 0.4},
+		}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			var users []map[string]any
+			if err := client.Get(ctx, "/Users", nil, &users); err != nil {
+				return nil, fmt.Errorf("failed to get users: %w", err)
+			}
+			items := make([]map[string]any, 0, len(users))
+			for _, u := range users {
+				items = append(items, jf.ExtractUserSummary(u))
+			}
+			return &mcp.ReadResourceResult{
+				Contents: []*mcp.ResourceContents{{
+					URI:      "jellyfin://users",
+					MIMEType: "application/json",
+					Text:     jf.FormatJSON(items),
+				}},
+			}, nil
+		})
+	}
 
 	// --- Reference Guides ---
 	registerGuides(server)
@@ -402,31 +420,33 @@ func RegisterResources(server *mcp.Server, client jf.Client) {
 	})
 
 	// --- jellyfin://users/{userId} (template) ---
-	server.AddResourceTemplate(&mcp.ResourceTemplate{
-		URITemplate: "jellyfin://users/{userId}",
-		Name:        "User Profile",
-		Title:       "User Profile",
-		Description: "User account details and policy settings",
-		MIMEType:    "application/json",
-		Annotations: &mcp.Annotations{Audience: []mcp.Role{"assistant"}, Priority: 0.5},
-	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
-		userID := strings.TrimPrefix(req.Params.URI, "jellyfin://users/")
-		if userID == "" {
-			return nil, fmt.Errorf("user ID is required in URI")
-		}
-		var user map[string]any
-		endpoint := fmt.Sprintf("/Users/%s", jf.SanitizeID(userID))
-		if err := client.Get(ctx, endpoint, nil, &user); err != nil {
-			return nil, fmt.Errorf("failed to get user: %w", err)
-		}
-		return &mcp.ReadResourceResult{
-			Contents: []*mcp.ResourceContents{{
-				URI:      req.Params.URI,
-				MIMEType: "application/json",
-				Text:     jf.FormatJSON(jf.ExtractDetailedUser(user)),
-			}},
-		}, nil
-	})
+	if includeAdmin {
+		server.AddResourceTemplate(&mcp.ResourceTemplate{
+			URITemplate: "jellyfin://users/{userId}",
+			Name:        "User Profile",
+			Title:       "User Profile",
+			Description: "User account details and policy settings",
+			MIMEType:    "application/json",
+			Annotations: &mcp.Annotations{Audience: []mcp.Role{"assistant"}, Priority: 0.5},
+		}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			userID := strings.TrimPrefix(req.Params.URI, "jellyfin://users/")
+			if userID == "" {
+				return nil, fmt.Errorf("user ID is required in URI")
+			}
+			var user map[string]any
+			endpoint := fmt.Sprintf("/Users/%s", jf.SanitizeID(userID))
+			if err := client.Get(ctx, endpoint, nil, &user); err != nil {
+				return nil, fmt.Errorf("failed to get user: %w", err)
+			}
+			return &mcp.ReadResourceResult{
+				Contents: []*mcp.ResourceContents{{
+					URI:      req.Params.URI,
+					MIMEType: "application/json",
+					Text:     jf.FormatJSON(jf.ExtractDetailedUser(user)),
+				}},
+			}, nil
+		})
+	}
 
 	// --- jellyfin://libraries/{libraryId}/latest (template) ---
 	server.AddResourceTemplate(&mcp.ResourceTemplate{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,6 +43,7 @@ func ToolsetNames() map[string][]string {
 // Run initialises the MCP server and starts the selected transport.
 func Run(cfg Config) {
 	client := jf.NewJellyfinClient()
+	includeAdminResources := resources.AdminResourcesEnabled(cfg.ReadOnly, cfg.Toolsets)
 
 	tracker := &subscriptionTracker{}
 	srv := mcp.NewServer(&mcp.Implementation{
@@ -51,7 +52,7 @@ func Run(cfg Config) {
 		Version: version,
 	}, &mcp.ServerOptions{
 		Instructions:       serverInstructions(),
-		CompletionHandler:  completionHandler(client),
+		CompletionHandler:  completionHandler(client, includeAdminResources),
 		SubscribeHandler:   subscribeHandler(tracker),
 		UnsubscribeHandler: unsubscribeHandler(tracker),
 	})
@@ -63,7 +64,7 @@ func Run(cfg Config) {
 	enabled := tools.BuildToolFilter(cfg.Toolsets, cfg.ReadOnly, cfg.DisableDestructive)
 
 	// Register all components
-	resources.RegisterResources(srv, client)
+	resources.RegisterResources(srv, client, includeAdminResources)
 	prompts.RegisterPrompts(srv, client)
 	tools.RegisterTools(srv, client, enabled)
 
@@ -184,7 +185,7 @@ func bearerAuth(next http.Handler, token string) http.Handler {
 }
 
 // completionHandler provides auto-completion for prompt arguments and resource template URIs.
-func completionHandler(client jf.Client) func(context.Context, *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
+func completionHandler(client jf.Client, includeAdmin bool) func(context.Context, *mcp.CompleteRequest) (*mcp.CompleteResult, error) {
 	// Prompt argument completions
 	promptCompletions := map[string]map[string][]string{
 		"find-and-play": {
@@ -272,6 +273,9 @@ func completionHandler(client jf.Client) func(context.Context, *mcp.CompleteRequ
 					}
 				}
 			case strings.HasPrefix(uri, "jellyfin://users/"):
+				if !includeAdmin {
+					break
+				}
 				partial := strings.ToLower(req.Params.Argument.Value)
 				var users []map[string]any
 				if err := client.Get(ctx, "/Users", nil, &users); err == nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"crypto/subtle"
 	"fmt"
 	"log"
 	"log/slog"
@@ -153,8 +152,8 @@ func runHTTP(server *mcp.Server, addr, token string) {
 		}
 	}()
 
-	if token == "" && !strings.HasPrefix(addr, "127.0.0.1") && !strings.HasPrefix(addr, "localhost") {
-		log.Fatalf("FATAL: --http-token is required when listening on non-localhost address %s", addr)
+	if err := validateHTTPAuth(addr, token); err != nil {
+		log.Fatalf("FATAL: %v", err)
 	}
 	if token == "" {
 		log.Printf("WARNING: HTTP mode without --http-token — MCP endpoint has no authentication (localhost only)")
@@ -165,23 +164,6 @@ func runHTTP(server *mcp.Server, addr, token string) {
 		log.Fatalf("server error: %v", err)
 	}
 	stop()
-}
-
-// bearerAuth wraps an http.Handler with bearer token authentication.
-// If token is empty, the handler is returned unwrapped (no auth).
-func bearerAuth(next http.Handler, token string) http.Handler {
-	if token == "" {
-		return next
-	}
-	expected := []byte("Bearer " + token)
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		actual := []byte(r.Header.Get("Authorization"))
-		if subtle.ConstantTimeCompare(actual, expected) != 1 {
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
 }
 
 // completionHandler provides auto-completion for prompt arguments and resource template URIs.

--- a/internal/server/tools/tools_test.go
+++ b/internal/server/tools/tools_test.go
@@ -107,13 +107,13 @@ func TestDisableDestructiveRemovesDestructiveTools(t *testing.T) {
 	}
 	for _, toolName := range destructiveTools {
 		if registered[toolName] {
-			t.Errorf("%s reste enregistré avec --disable-destructive", toolName)
+			t.Errorf("%s remains registered with --disable-destructive", toolName)
 		}
 		if _, err := session.CallTool(t.Context(), &mcp.CallToolParams{
 			Name:      toolName,
 			Arguments: map[string]any{"confirm": true},
 		}); err == nil {
-			t.Errorf("%s reste appelable avec --disable-destructive", toolName)
+			t.Errorf("%s remains callable with --disable-destructive", toolName)
 		}
 	}
 }

--- a/internal/server/tools/tools_test.go
+++ b/internal/server/tools/tools_test.go
@@ -72,6 +72,52 @@ func TestBuildToolFilter_DisableDestructive(t *testing.T) {
 	}
 }
 
+func TestDisableDestructiveRemovesDestructiveTools(t *testing.T) {
+	mc := &mockClient{}
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.1"}, nil)
+	tools.RegisterTools(srv, mc, tools.BuildToolFilter("", false, true))
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	if _, err := srv.Connect(t.Context(), serverTransport, nil); err != nil {
+		t.Fatal(err)
+	}
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.1"}, nil)
+	session, err := client.Connect(t.Context(), clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+
+	list, err := session.ListTools(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registered := make(map[string]bool, len(list.Tools))
+	for _, tool := range list.Tools {
+		registered[tool.Name] = true
+	}
+
+	destructiveTools := []string{
+		"jellyfin_system_control",
+		"jellyfin_users",
+		"jellyfin_library_manage",
+		"jellyfin_devices",
+		"jellyfin_recordings",
+		"jellyfin_videos",
+	}
+	for _, toolName := range destructiveTools {
+		if registered[toolName] {
+			t.Errorf("%s reste enregistré avec --disable-destructive", toolName)
+		}
+		if _, err := session.CallTool(t.Context(), &mcp.CallToolParams{
+			Name:      toolName,
+			Arguments: map[string]any{"confirm": true},
+		}); err == nil {
+			t.Errorf("%s reste appelable avec --disable-destructive", toolName)
+		}
+	}
+}
+
 func TestBuildToolFilter_NilAnnotations(t *testing.T) {
 	enabled := tools.BuildToolFilter("", false, false)
 	// Tools with nil annotations should be enabled when no filter is active

--- a/main.go
+++ b/main.go
@@ -45,9 +45,10 @@ func usageTemplate() string {
   {{.UseLine}}{{end}}
 
 Environment variables:
-  JELLYFIN_URL        Server URL (default: https://jellyfin_host:8920)
-  JELLYFIN_API_KEY    API key (required)
-  JELLYFIN_USER_ID    User ID (optional, auto-detected if not set)
+  JELLYFIN_URL              URL HTTP(S) du serveur (obligatoire)
+  JELLYFIN_API_KEY          Clé API (obligatoire)
+  JELLYFIN_USER_ID          ID utilisateur (optionnel, détecté automatiquement sinon)
+  JELLYFIN_REQUIRE_USER_ID  Exige JELLYFIN_USER_ID et interdit le fallback administrateur
 
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}

--- a/main.go
+++ b/main.go
@@ -45,10 +45,10 @@ func usageTemplate() string {
   {{.UseLine}}{{end}}
 
 Environment variables:
-  JELLYFIN_URL              URL HTTP(S) du serveur (obligatoire)
-  JELLYFIN_API_KEY          Clé API (obligatoire)
-  JELLYFIN_USER_ID          ID utilisateur (optionnel, détecté automatiquement sinon)
-  JELLYFIN_REQUIRE_USER_ID  Exige JELLYFIN_USER_ID et interdit le fallback administrateur
+  JELLYFIN_URL              Jellyfin server HTTP(S) URL (required)
+  JELLYFIN_API_KEY          API key (required)
+  JELLYFIN_USER_ID          User ID (optional, auto-detected when omitted)
+  JELLYFIN_REQUIRE_USER_ID  Require JELLYFIN_USER_ID and disable admin fallback
 
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}

--- a/npm/jellyfin-mcp/README.md
+++ b/npm/jellyfin-mcp/README.md
@@ -93,7 +93,7 @@ Append flags after the package name in the `args` array:
 | Flag | Description |
 |------|-------------|
 | `--toolsets` | Comma-separated groups: `discovery`, `media`, `user`, `playback`, `admin`, `content`, `analytics`, `livetv` |
-| `--read-only` | Only register read-only tools |
+| `--read-only` | Enregistre uniquement les outils en lecture seule et masque les ressources/complétions utilisateur orientées administration |
 | `--disable-destructive` | Skip destructive tools (delete, restart, shutdown) |
 
 ## Tools (31)

--- a/npm/jellyfin-mcp/README.md
+++ b/npm/jellyfin-mcp/README.md
@@ -77,9 +77,10 @@ Any client that supports the `mcpServers` JSON format (Cursor, VS Code Copilot, 
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `JELLYFIN_API_KEY` | Yes | — | API key from your Jellyfin dashboard |
-| `JELLYFIN_URL` | No | — | Server URL, e.g. `http://YOUR_SERVER:8096` (or `https://YOUR_SERVER:8920` if HTTPS is enabled) |
-| `JELLYFIN_USER_ID` | No | auto-detected | User ID for user-scoped operations |
+| `JELLYFIN_API_KEY` | Yes | — | Clé API créée depuis le tableau de bord Jellyfin |
+| `JELLYFIN_URL` | Yes | — | URL HTTP(S) du serveur. L'hôte d'exemple `jellyfin_host` est refusé au démarrage. |
+| `JELLYFIN_USER_ID` | No | auto-detected | ID utilisateur pour les opérations liées à un compte |
+| `JELLYFIN_REQUIRE_USER_ID` | No | `false` | Avec `true` ou `1`, exige `JELLYFIN_USER_ID` et interdit tout fallback administrateur. `--read-only` n'active pas ce mode. |
 
 ## CLI flags
 

--- a/npm/jellyfin-mcp/README.md
+++ b/npm/jellyfin-mcp/README.md
@@ -77,10 +77,10 @@ Any client that supports the `mcpServers` JSON format (Cursor, VS Code Copilot, 
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `JELLYFIN_API_KEY` | Yes | — | Clé API créée depuis le tableau de bord Jellyfin |
-| `JELLYFIN_URL` | Yes | — | URL HTTP(S) du serveur. L'hôte d'exemple `jellyfin_host` est refusé au démarrage. |
-| `JELLYFIN_USER_ID` | No | auto-detected | ID utilisateur pour les opérations liées à un compte |
-| `JELLYFIN_REQUIRE_USER_ID` | No | `false` | Avec `true` ou `1`, exige `JELLYFIN_USER_ID` et interdit tout fallback administrateur. `--read-only` n'active pas ce mode. |
+| `JELLYFIN_API_KEY` | Yes | None | API key from your Jellyfin dashboard |
+| `JELLYFIN_URL` | Yes | None | Jellyfin server HTTP(S) URL. The `jellyfin_host` placeholder is rejected at startup. |
+| `JELLYFIN_USER_ID` | No | auto-detected | User ID for user-scoped operations |
+| `JELLYFIN_REQUIRE_USER_ID` | No | `false` | When `true` or `1`, require `JELLYFIN_USER_ID` and disable automatic user selection, including admin fallback. `--read-only` does not enable this strict mode. |
 
 ## CLI flags
 
@@ -93,7 +93,7 @@ Append flags after the package name in the `args` array:
 | Flag | Description |
 |------|-------------|
 | `--toolsets` | Comma-separated groups: `discovery`, `media`, `user`, `playback`, `admin`, `content`, `analytics`, `livetv` |
-| `--read-only` | Enregistre uniquement les outils en lecture seule et masque les ressources/complétions utilisateur orientées administration |
+| `--read-only` | Only register read-only tools and hide admin-oriented user resources and completions |
 | `--disable-destructive` | Skip destructive tools (delete, restart, shutdown) |
 
 ## Tools (31)


### PR DESCRIPTION
## Summary

- Validate `JELLYFIN_URL` at startup and reject missing, malformed, non-HTTP(S), and placeholder values.
- Add opt-in `JELLYFIN_REQUIRE_USER_ID` enforcement while preserving the existing user auto-detection behavior by default.
- Bound `PostRaw` error response reads and resolve the cached user ID without holding a mutex during HTTP requests.
- Hide admin user resources and user-ID completions in `--read-only` mode or when `--toolsets` omits `admin`.
- Isolate and test HTTP bearer authentication and non-localhost binding checks.

## Safety boundaries

- Preserve the existing structural `--disable-destructive` policy: tools annotated `AnnotDestructive` are not registered and cannot be invoked while the flag is active.
- `confirm=true` remains an operation-level confirmation only. It is not a human-confirmation boundary and does not replace structural tool exclusion.
- `--read-only` does not enable strict user selection. Set both `JELLYFIN_REQUIRE_USER_ID=true` and an explicit `JELLYFIN_USER_ID` to prevent user auto-detection and admin fallback.

## Test plan

- [x] `go vet ./...`
- [x] `go test -count=1 ./...`
- [x] `go test -race -count=1 ./...`
- [x] `git diff --check upstream/main...HEAD`
- [ ] GitHub Actions

`golangci-lint` was not run locally because the binary is not installed; the repository CI workflow is unchanged.